### PR TITLE
Add test for the `Pry::Method` conflict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ownership.gemspec
 gemspec
+
+group :test do
+  gem 'pry', require: false
+end

--- a/test/ownership_test.rb
+++ b/test/ownership_test.rb
@@ -32,4 +32,12 @@ class OwnershipTest < Minitest::Test
     end
     assert_equal error.owner, :logistics
   end
+
+  def test_pry_method_does_not_bomb
+    assert Kernel, method(:puts).owner
+
+    require 'pry'
+
+    Pry::Method.new(method(:puts)).wrapped_owner
+  end
 end


### PR DESCRIPTION
Pry is a debugging tool that gives you a much nicer REPL for debugging
purposes. Has a class called `Pry::Method` that wraps `Method` objects
and adds some more information for the REPL to work with.

Because of Ownership's monkey-patching of `Object` to include the
`owner` method, Pry doesn't work properly when Ownership has been
required. Specifically, [this line][1] bombs out because the `owner`
method that it's expecting is the wrapped method's `owner` method
through the [`method_missing` declaration on the class][2].

This change introduces a test that shows the breakage.

Given that `owner` is a very generic name, I thought of a few ways we
could solve this issue:

1. Instead of doing `Object.include Ownership::GlobalMethods` by
   default, the gem could enforce configuring it by adding an
   `Ownership.monkey_patch :owner` or similar method to allow the
   implemented method to be named according to the user's preference.
2. We could rename the method to `code_owner` to make it more specific
   and less likely to conflict.
3. We could rely on implementations of plugins that specifically
   reference the `Ownership::GlobalMethods#owner` method (and either
   relocate that method or make it a module method).

What do you think?

[1]: https://github.com/pry/pry/blob/v0.12.2/lib/pry/method.rb#L250
[2]: https://github.com/pry/pry/blob/v0.12.2/lib/pry/method.rb#L475-L477