### PR TITLE
Add support for Honeybadger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Honeybadger integration
+
 ## 0.1.0
 
 - First release

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ownership.gemspec
 gemspec
+
+group :test do
+  gem "honeybadger", require: false
+  gem 'pry'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ownership.gemspec
 gemspec
-
-group :test do
-  gem "honeybadger", require: false
-  gem 'pry'
-end

--- a/README.md
+++ b/README.md
@@ -91,6 +91,40 @@ Also works with a proc
 Ownership::Rollbar.access_token = -> (owner) { ENV["#{owner.to_s.upcase}_ROLLBAR_ACCESS_TOKEN"] }
 ```
 
+### Honeybadger
+
+[Honeybadger](https://github.com/honeybadger-io/honeybadger-ruby) tracks exceptions. This integration makes it easy to send exceptions to different projects based on the owner. We recommend having a project for each team.
+
+```ruby
+Ownership::Honeybadger.api_keys = {
+  logistics: "token1",
+  customers: "token2"
+}
+```
+
+Owner lookup also works with a proc:
+
+```ruby
+Ownership::Honeybadger.api_keys = -> (owner) { ENV["#{owner.to_s.upcase}_HONEYBADGER_API_KEY"] }
+```
+
+If you want to re-route a notice based on context, you can pass an `ownership_owner` key to the notify call, as follows:
+
+```ruby
+Honeybadger.notify("Something wicked, this way comes", context: {
+ownership_owner: :logistics })
+
+# or, in separate calls
+Honeybadger.context(ownership_owner: :logistics)
+Honeybadger.notify("Something wicked, this way comes")
+```
+
+The preference for which owner owns a given notification is:
+
+1. The `owner` of the exception, if an exception is attached to the notice. This is set by the `owner` method used throughout the integrations, when an exception occurs.
+2. The `ownership_owner` set in the context for the notice, if any.
+3. The current `Ownership.owner`, if any.
+
 ## Custom Integrations
 
 You can define a custom block of code to run with:

--- a/README.md
+++ b/README.md
@@ -108,23 +108,6 @@ Owner lookup also works with a proc:
 Ownership::Honeybadger.api_keys = -> (owner) { ENV["#{owner.to_s.upcase}_HONEYBADGER_API_KEY"] }
 ```
 
-If you want to re-route a notice based on context, you can pass an `ownership_owner` key to the notify call, as follows:
-
-```ruby
-Honeybadger.notify("Something wicked, this way comes", context: {
-ownership_owner: :logistics })
-
-# or, in separate calls
-Honeybadger.context(ownership_owner: :logistics)
-Honeybadger.notify("Something wicked, this way comes")
-```
-
-The preference for which owner owns a given notification is:
-
-1. The `owner` of the exception, if an exception is attached to the notice. This is set by the `owner` method used throughout the integrations, when an exception occurs.
-2. The `ownership_owner` set in the context for the notice, if any.
-3. The current `Ownership.owner`, if any.
-
 ## Custom Integrations
 
 You can define a custom block of code to run with:

--- a/lib/ownership.rb
+++ b/lib/ownership.rb
@@ -1,4 +1,5 @@
 require "ownership/global_methods"
+require "ownership/honeybadger"
 require "ownership/rollbar"
 require "ownership/version"
 

--- a/lib/ownership/honeybadger.rb
+++ b/lib/ownership/honeybadger.rb
@@ -21,7 +21,6 @@ module Ownership
         ::Honeybadger.configure do |config|
           config.before_notify do |notice|
             current_owner = notice.exception.owner if notice.exception.is_a?(Exception)
-            current_owner ||= notice.context[:ownership_owner]
             current_owner ||= Ownership.owner
 
             add_owner_as_tag(notice, current_owner)

--- a/lib/ownership/honeybadger.rb
+++ b/lib/ownership/honeybadger.rb
@@ -1,0 +1,48 @@
+module Ownership
+  module Honeybadger
+    class << self
+      attr_reader :api_keys
+
+      def api_keys=(api_keys)
+        @api_keys = api_keys
+        @configuration ||= configure
+        api_keys
+      end
+
+      private
+
+      def add_owner_as_tag(notice, current_owner)
+        return unless current_owner
+
+        notice.tags << current_owner.to_s
+      end
+
+      def configure
+        ::Honeybadger.configure do |config|
+          config.before_notify do |notice|
+            current_owner = notice.exception.owner if notice.exception.is_a?(Exception)
+            current_owner ||= notice.context[:ownership_owner]
+            current_owner ||= Ownership.owner
+
+            add_owner_as_tag(notice, current_owner)
+            use_owner_api_key(notice, current_owner)
+          end
+        end
+      end
+
+      def owner_api_key(current_owner)
+        api_keys.respond_to?(:call) ? api_keys.call(current_owner) : api_keys[current_owner]
+      end
+
+      def use_owner_api_key(notice, current_owner)
+        return unless current_owner
+
+        if (api_key = owner_api_key(current_owner))
+          notice.api_key = api_key
+        else
+          warn "[ownership] Missing Honeybadger API key for owner: #{current_owner}"
+        end
+      end
+    end
+  end
+end

--- a/ownership.gemspec
+++ b/ownership.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ownership/version"
@@ -24,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "activejob"
   spec.add_development_dependency "marginalia"
+  spec.add_development_dependency "honeybadger"
 end

--- a/test/honeybadger_test.rb
+++ b/test/honeybadger_test.rb
@@ -1,0 +1,113 @@
+require_relative "test_helper"
+
+# Silence the boot up message from Honeybadger
+begin
+  original_stdout, $stdout = $stdout, StringIO.new
+  original_stderr, $stderr = $stderr, StringIO.new
+  require "honeybadger/ruby"
+  Honeybadger.init!(framework: :ruby, env: "test", :"logging.path" => "STDOUT")
+ensure
+  $stdout, $stderr = original_stdout, original_stderr
+end
+
+Honeybadger.configure do |config|
+  config.api_key = "default-key"
+  config.backend = "test"
+  config.logger = Logger.new(IO::NULL)
+end
+
+Ownership::Honeybadger.api_keys = {
+  logistics: "logistics-key",
+  sales: "sales-key",
+  support: "support-key"
+}
+
+class HoneybadgerTest < Minitest::Test
+  def setup
+    $around_calls = []
+
+    Honeybadger.config.backend.notifications.clear
+    Honeybadger.context.clear!
+  end
+
+  def test_tagging
+    Honeybadger.context tags: 'critical, badgers'
+
+    owner :logistics do
+      Honeybadger.notify("boom for logistics", sync: true)
+    end
+
+    assert_equal %w[critical badgers logistics], notices.last.tags
+
+    Honeybadger.context.clear!
+
+    owner :sales do
+      Honeybadger.notify("boom for sales", sync: true)
+    end
+
+    assert_equal %w[sales], notices.last.tags
+  end
+
+  def test_uses_default_key_without_ownership_block
+    Honeybadger.notify("boom for default", sync: true)
+
+    assert_equal "default-key", notices.last.api_key
+  end
+
+  def test_uses_owner_key_within_ownership_block
+    owner :logistics do
+      Honeybadger.notify("boom for logistics", sync: true)
+    end
+
+    assert_equal "logistics-key", notices.last.api_key
+  end
+
+  def test_uses_default_key_and_warns_with_unknown_owner
+    assert_output(nil, /Missing Honeybadger API key for owner: unknown/) do
+      owner :unknown do
+        Honeybadger.notify("boom for default", sync: true)
+      end
+    end
+
+    assert_equal "default-key", notices.last.api_key
+  end
+
+  def test_async_works_properly
+    owner :logistics do
+      Honeybadger.notify("boom for logistics")
+      Honeybadger.flush
+    end
+
+    assert_equal "logistics-key", notices.last.api_key
+  end
+
+  def test_prefer_exception_owner_over_all_else
+    owner :logistics do
+      ex = StandardError.new("boom for sales")
+      ex.owner = :sales
+
+      Honeybadger.notify(ex, sync: true, context: { ownership_owner: :support })
+    end
+
+    assert_equal "sales-key", notices.last.api_key
+  end
+
+  def test_prefer_context_ownership_over_thread_local_ownership
+    owner :logistics do
+      Honeybadger.notify("boom", sync: true, context: { ownership_owner: :support })
+    end
+
+    assert_equal "support-key", notices.last.api_key
+
+    Honeybadger.context(ownership_owner: :sales)
+    Honeybadger.notify("boom", sync: true)
+
+    assert_equal "sales-key", notices.last.api_key
+  end
+
+  private
+
+  def notices
+    Honeybadger.config.backend.notifications[:notices]
+  end
+end


### PR DESCRIPTION
Honeybadger is another exception service, like Rollbar. This change
introduces awareness of Ownership to Honeybadger. We [tag][1] each
notice with the current owner to allow you to filter by owner within
a single project.

Additionally, you can toggle between different API keys to route errors
to different projects to further segregate your errors for individual
teams. This requires configuration in the form:

```ruby
Ownership::Honeybadger.api_keys = {
  logistics: 'logistics-key',
  platform: 'platform-key'
}
```

If there is no separate key, we fall back to using the default key.

[1]: https://docs.honeybadger.io/lib/ruby/getting-started/tagging-errors.html