### PR TITLE
Allow claiming ownership of methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ end
 
 ```ruby
 class MyClass
-  include Ownership::Owner.for(:call, owner: :logistics)
+  owner :logistics, methods: [:call]
 
   def call
     # anything in here is wrapped with a call to `owner :logistics`
@@ -63,11 +63,13 @@ class MyClass
 end
 ```
 
-If you would like to claim ownership of a class method, `extend` the Owner module instead of including it:
+If you would like to claim ownership of a class method, call `owner` in the context of the singleton class instead:
 
 ```ruby
 class MyClass
-  extend Ownership::Owner.for(:call, owner: :sales)
+  class << self
+    owner :sales, methods: [:call]
+  end
 
   def self.call
     # anything in here is wrapped with a call to `owner :sales`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ owner :logistics do
 end
 ```
 
+### Claiming ownership of methods within classes
+
+```ruby
+class MyClass
+  include Ownership::Owner.for(:call, owner: :logistics)
+
+  def call
+    # anything in here is wrapped with a call to `owner :logistics`
+  end
+end
+```
+
 ### Default
 
 You can set a default owner with:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ class MyClass
 end
 ```
 
+If you would like to claim ownership of a class method, `extend` the Owner module instead of including it:
+
+```ruby
+class MyClass
+  extend Ownership::Owner.for(:call, owner: :sales)
+
+  def self.call
+    # anything in here is wrapped with a call to `owner :sales`
+  end
+end
+```
+
 ### Default
 
 You can set a default owner with:

--- a/lib/ownership.rb
+++ b/lib/ownership.rb
@@ -1,5 +1,6 @@
 require "ownership/global_methods"
 require "ownership/honeybadger"
+require "ownership/owner"
 require "ownership/rollbar"
 require "ownership/version"
 

--- a/lib/ownership/global_methods.rb
+++ b/lib/ownership/global_methods.rb
@@ -5,28 +5,40 @@ module Ownership
     def owner(*args, &block)
       return super if is_a?(Method) # hack for pry
 
-      owner = args[0]
+      owner = args.first
+      kwargs =
+        case args.last
+        when Hash then args.pop
+        else {}
+        end
+
+      methods = kwargs.fetch(:methods, :__not_set__)
       # same error message as Ruby
       raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 1)" if args.size != 1
-      raise ArgumentError, "Missing block" unless block_given?
 
-      previous_value = Thread.current[:ownership_owner]
-      begin
-        Thread.current[:ownership_owner] = owner
-
+      if block_given?
+        previous_value = Thread.current[:ownership_owner]
         begin
-          # callbacks
-          if Ownership.around_change
-            Ownership.around_change.call(owner, block)
-          else
-            block.call
+          Thread.current[:ownership_owner] = owner
+
+          begin
+            # callbacks
+            if Ownership.around_change
+              Ownership.around_change.call(owner, block)
+            else
+              block.call
+            end
+          rescue Exception => e
+            e.owner = owner
+            raise
           end
-        rescue Exception => e
-          e.owner = owner
-          raise
+        ensure
+          Thread.current[:ownership_owner] = previous_value
         end
-      ensure
-        Thread.current[:ownership_owner] = previous_value
+      elsif methods == :__not_set__
+        raise ArgumentError, "Missing block"
+      else
+        self.include Ownership::Owner.for(*methods, owner: owner)
       end
     end
   end

--- a/lib/ownership/owner.rb
+++ b/lib/ownership/owner.rb
@@ -13,6 +13,10 @@ module Ownership
         singleton_class.__send__(:define_method, :included) do |base|
           base.prepend(mod)
         end
+
+        singleton_class.__send__(:define_method, :extended) do |base|
+          base.singleton_class.prepend(mod)
+        end
       end
     end
 

--- a/lib/ownership/owner.rb
+++ b/lib/ownership/owner.rb
@@ -1,0 +1,29 @@
+module Ownership
+  module Owner
+    def self.for(*methods, owner:)
+      mod = Module.new do
+        methods.each { |method_name| Owner.wrap_method(self, method_name, owner) }
+
+        singleton_class.__send__(:define_method, :inspect) do
+          "Ownership::Owner.for<#{methods.join(", ")}>"
+        end
+      end
+
+      Module.new do
+        singleton_class.__send__(:define_method, :included) do |base|
+          base.prepend(mod)
+        end
+      end
+    end
+
+    def self.wrap_method(target, method_name, owner)
+      target.module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        def #{method_name}(*)
+          owner #{owner.inspect} do
+            super
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/lib/ownership/owner.rb
+++ b/lib/ownership/owner.rb
@@ -17,6 +17,10 @@ module Ownership
         singleton_class.__send__(:define_method, :extended) do |base|
           base.singleton_class.prepend(mod)
         end
+
+        singleton_class.__send__(:define_method, :inspect) do
+          "Ownership::OwnerInjector"
+        end
       end
     end
 

--- a/test/owner_test.rb
+++ b/test/owner_test.rb
@@ -22,4 +22,22 @@ class OwnerTest < Minitest::Test
       assert_equal :logistics, ex.owner
     end
   end
+
+  def test_owner_for_class_method
+    klass = Class.new do
+      extend Ownership::Owner.for :call, owner: :sales
+
+      def self.call
+        raise "boom"
+      end
+    end
+
+    assert_equal "Ownership::Owner.for<call>", klass.method(:call).owner.inspect
+
+    begin
+      klass.call
+    rescue => ex
+      assert_equal :sales, ex.owner
+    end
+  end
 end

--- a/test/owner_test.rb
+++ b/test/owner_test.rb
@@ -1,0 +1,25 @@
+require_relative "test_helper"
+
+class OwnerTest < Minitest::Test
+  def setup
+    $around_calls = []
+  end
+
+  def test_owner_for_call_method
+    klass = Class.new do
+      include Ownership::Owner.for :call, owner: :logistics
+
+      def call
+        raise "boom"
+      end
+    end
+
+    assert_equal "Ownership::Owner.for<call>", klass.instance_method(:call).owner.inspect
+
+    begin
+      klass.new.call
+    rescue => ex
+      assert_equal :logistics, ex.owner
+    end
+  end
+end

--- a/test/ownership_test.rb
+++ b/test/ownership_test.rb
@@ -44,4 +44,32 @@ class OwnershipTest < Minitest::Test
   def test_pry
     assert_equal Kernel, Pry::Method.new(method(:puts)).wrapped_owner.wrapped
   end
+
+  def test_claiming_instance_method
+    klass = Class.new do
+      owner :logistics, methods: [:call]
+
+      def call
+        raise "boom"
+      end
+    end
+
+    error = assert_raises { klass.new.call }
+    assert_equal error.owner, :logistics
+  end
+
+  def test_claiming_singleton_method
+    klass = Class.new do
+      class << self
+        owner :sales, methods: [:call]
+      end
+
+      def self.call
+        raise "boom"
+      end
+    end
+
+    error = assert_raises { klass.call }
+    assert_equal error.owner, :sales
+  end
 end


### PR DESCRIPTION
Instead of requiring individual blocks of code to be wrapped in `owner`
blocks, this change introduces an `Owner` wrapper that allows you define
that you want to wrap a method automatically. This generates a module
that generates wrapper methods to prepend on the including module or
class.

This looks like the following:

```ruby
class MyCommand
  include Ownership::Owner.for(:call, owner: :logistics)

  def call
    # do your work
  end
end
```

If you'd like to claim a class/module method, use extend instead:

```ruby
class MyService
  extend Ownership::Owner.for(:call, owner: :sales)

  def self.call
    # do your work
  end
end
```

Both of these use `Module.prepend` so require Ruby 2.0, but I think that's a reasonable requirement! 😄 