### PR TITLE
Fix owner when owner blocks are nested

### DIFF
--- a/lib/ownership/global_methods.rb
+++ b/lib/ownership/global_methods.rb
@@ -22,7 +22,7 @@ module Ownership
             block.call
           end
         rescue Exception => e
-          e.owner = owner
+          e.owner ||= owner
           raise
         end
       ensure

--- a/test/ownership_test.rb
+++ b/test/ownership_test.rb
@@ -27,6 +27,17 @@ class OwnershipTest < Minitest::Test
     assert_equal error.owner, :logistics
   end
 
+  def test_nested_exception
+    error = assert_raises do
+      owner :logistics do
+        owner :sales do
+          raise "boom"
+        end
+      end
+    end
+    assert_equal error.owner, :sales
+  end
+
   def test_respond_to?
     assert !nil.respond_to?(:owner)
   end


### PR DESCRIPTION
The owner block was unconditionally setting the owner on error, which would cause
a nested owner to be overriden by the outer block