### PR TITLE
Remove conditional Active Record 7 code

### DIFF
--- a/lib/ownership.rb
+++ b/lib/ownership.rb
@@ -25,11 +25,9 @@ if defined?(ActiveSupport)
   end
 
   ActiveSupport.on_load(:active_record) do
-    if ActiveRecord::VERSION::MAJOR >= 7
-      # taggings is frozen in Active Record 8
-      if !ActiveRecord::QueryLogs.taggings[:owner]
-        ActiveRecord::QueryLogs.taggings = ActiveRecord::QueryLogs.taggings.merge({owner: -> { Ownership.owner }})
-      end
+    # taggings is frozen in Active Record 8
+    if !ActiveRecord::QueryLogs.taggings[:owner]
+      ActiveRecord::QueryLogs.taggings = ActiveRecord::QueryLogs.taggings.merge({owner: -> { Ownership.owner }})
     end
 
     require_relative "ownership/marginalia" if defined?(Marginalia)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -5,8 +5,6 @@ ActiveRecord::Base.logger = ActiveSupport::Logger.new($io)
 
 class ActiveRecordTest < Minitest::Test
   def setup
-    skip if ActiveRecord::VERSION::MAJOR < 7
-
     ActiveRecord::QueryLogs.tags = [:owner]
     super
     $io.truncate(0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,7 @@ Combustion.initialize! :active_record, :action_controller, :active_job do
   config.action_controller.logger = logger
   config.active_record.logger = logger
   config.active_job.logger = logger
-
-  if ActiveRecord::VERSION::MAJOR >= 7
-    config.active_record.query_log_tags_enabled = true
-  end
+  config.active_record.query_log_tags_enabled = true
 
   require "marginalia"
 end


### PR DESCRIPTION
Since support for active record < 7 was removed, these checks are not needed.